### PR TITLE
Minor changes to Angel PR #4564

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -294,6 +294,9 @@ che.openshift.liveness.probe.delay=300
 che.openshift.liveness.probe.timeout=1
 che.openshift.workspaces.pvc.name=claim-che-workspace
 che.openshift.workspaces.pvc.quantity=10Gi
+che.openshift.workspace.cpu.limit=1
+che.openshift.workspace.cpu.request=1
+che.openshift.workspace.memory.request=128Mi
 
 # Which implementation of DockerConnector to use in managing containers. In general,
 # the base implementation of DockerConnector is appropriate, but OpenShiftConnector

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -38,7 +38,10 @@ public class OpenShiftConnectorTest {
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_STORAGE = "/data/workspaces";
     private static final String   OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE = "/projects";
 	private static final String   CHE_DEFAULT_SERVER_EXTERNAL_ADDRESS = "che.openshift.mini";
-	
+	private static final String   CHE_WORKSPACE_CPU_LIMIT = "1";
+	private static final String   CHE_WORKSPACE_CPU_REQUEST = "1";
+	private static final String   CHE_WORKSPACE_MEMORY_REQUEST = "128Mi";
+
     @Mock
     private DockerConnectorConfiguration       dockerConnectorConfiguration;
     @Mock
@@ -73,7 +76,10 @@ public class OpenShiftConnectorTest {
                                                     OPENSHIFT_DEFAULT_WORKSPACE_PERSISTENT_VOLUME_CLAIM,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_QUANTITY,
                                                     OPENSHIFT_DEFAULT_WORKSPACE_STORAGE,
-                                                    OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE);
+                                                    OPENSHIFT_DEFAULT_WORKSPACE_PROJECTS_STORAGE,
+                                                    CHE_WORKSPACE_CPU_LIMIT,
+                                                    CHE_WORKSPACE_CPU_REQUEST,
+                                                    CHE_WORKSPACE_MEMORY_REQUEST);
         String workspaceID = openShiftConnector.getCheWorkspaceId(createContainerParams);
 
         //Then


### PR DESCRIPTION
That PR should not be merged but just used as a reference to the modifications I did to make the PR work. 

I'm adding the following env variables when starting che-server:

```yaml
      spec:
        containers:
        - env:
          - name: JAVA_OPTS
            value: "-Xms256M -Xmx256M"
          - name: CHE_WORKSPACE_JAVA_OPTIONS
            value: "-Xms256m -Xmx512M -Djava.security.egd=file:/dev/./urandom"
          - name: CHE_WORKSPACE_MAVEN_OPTIONS
            value: "-Xms256m -Xmx512M -Djava.security.egd=file:/dev/./urandom"
          - name: CHE_WORKSPACE_AGENT_DEV_MAX__START__TIME__MS
            value: "360000"
          - name: CHE_WORKSPACE_DEFAULT__MEMORY__MB
            value: "512"
```